### PR TITLE
Bump the pip group across 1 directories with 2 updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles
 bard
 SpeechRecognition
 pornhub-api==0.2.0
-aiohttp==3.9.1
+aiohttp==3.9.2
 asyncio==3.4.3
 beautifulsoup4
 daxxhub
@@ -18,7 +18,7 @@ pycountry
 heroku3
 apscheduler
 motor==3.3.2
-pillow==9.5.0
+pillow==10.2.0
 psutil
 wget
 pyfiglet


### PR DESCRIPTION
Bumps the pip group with 2 updates in the /. directory: [aiohttp](https://github.com/aio-libs/aiohttp) and [pillow](https://github.com/python-pillow/Pillow).


Updates `aiohttp` from 3.9.1 to 3.9.2
- [Release notes](https://github.com/aio-libs/aiohttp/releases)
- [Changelog](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst)
- [Commits](https://github.com/aio-libs/aiohttp/compare/v3.9.1...v3.9.2)

Updates `pillow` from 9.5.0 to 10.2.0
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/9.5.0...10.2.0)

---
updated-dependencies:
- dependency-name: aiohttp dependency-type: direct:production dependency-group: pip-security-group
- dependency-name: pillow dependency-type: direct:production dependency-group: pip-security-group ...